### PR TITLE
Updated request package. Added gzip support in request if accept-enco…

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "mkdirp": "^0.5.1",
     "morgan": "^1.6.1",
     "pify": "^2.3.0",
-    "request": "^2.67.0",
+    "request": "^2.81.0",
     "serve-favicon": "^2.3.0",
     "toml": "^2.3.0",
     "touch": "^1.0.0",

--- a/src/app-utils.js
+++ b/src/app-utils.js
@@ -104,9 +104,14 @@ export function resolveMockPath (req, dataRoot) {
 }
 
 export function passthru (res, options) {
+  const zlib = require('zlib');
   try {
     res.writeHead(options.code || 200, options.headers);
-    res.write(options.body);
+    if (options.headers['content-encoding'] && options.headers['content-encoding'] === 'gzip') {
+      res.write(zlib.gzipSync(options.body));
+    } else {
+      res.write(options.body);
+    }
     res.end();
   } catch (e) {
     console.warn('Error writing response', e);

--- a/src/mock-proxy.js
+++ b/src/mock-proxy.js
@@ -41,6 +41,9 @@ const middleware = () => (req, res, next) => {
   const url = req.conf.host + req.urlToProxy;
   const method = req.method.toLowerCase();
   const urlConf = {url, timeout, headers: req.headers};
+  if (urlConf.headers['accept-encoding'] && urlConf.headers['accept-encoding'] === 'gzip') {
+    urlConf.gzip = true;
+  }
   // Remove encoding because we've processed the body already.
   delete urlConf.headers['content-encoding'];
   // Reset host


### PR DESCRIPTION
…ding is gzip, which will save the decompressed response. Added compression if content-encoding is set to gzip in the mocked response